### PR TITLE
replacing json.dumps with flask jsonify helper wrapper

### DIFF
--- a/movie_project/app/home/views.py
+++ b/movie_project/app/home/views.py
@@ -4,7 +4,7 @@
 __author__ = 'Henry'
 
 from . import home
-from flask import render_template, url_for, redirect, flash, session, request
+from flask import render_template, url_for, redirect, flash, session, request, jsonify
 from app.home.forms import RegistForm, LoginForm, UserdetailForm, PwdForm,CommentForm
 from app.models import User, Userlog, Comment, Movie,Preview,Tag,Moviecol
 from app import db, app
@@ -329,8 +329,7 @@ def moviecol_add():
         db.session.add(moviecol)
         db.session.commit()
         data = dict(ok=1)
-    import json
-    return json.dumps(data) #浏览器返回一个json:{"ok": 1}
+    return jsonify(data) #浏览器返回一个json:{"ok": 1}
     # return json.dumps(dict(ok=1))
 
 


### PR DESCRIPTION
Hi Henry,

We have a free program analysis tool for Python based web projects, called Bento. While we were scanning GitHub projects for issues, your project triggered a warning for using json.dumps() instead of flask jsonify().

According to this Stackoverflow article (https://stackoverflow.com/questions/7907596/json-dumps-vs-flask-jsonify), the jsonify() function in flask returns a flask.Response() object that already has the appropriate content-type header 'application/json' for use with json responses. It also has support for handling multiple args / kwargs, including lists. Hopefully, you'll find this PR useful.

Bento flagged few other issues related to Python3 compatibility, but I didn't want to touch those issues in this PR. If you are interested, feel free download and give Bento a try (https://bento.dev).